### PR TITLE
chore: use `>=` in pyproject.toml

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -893,5 +893,5 @@ bracex = ">=2.1.1"
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.12"
-content-hash = "ceaa4a612bc0b823fa115c61ba93d07c00579430b0cdfd427ff69ab0a11ce32e"
+python-versions = ">=3.12.3,<4.0"
+content-hash = "db28733d44f57a2d904e57baa25cce5619e175ab67107d0cec1e5e416f701657"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,8 @@ authors = ["Charly Laurent <charly.laurent@mergify.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.12"
-sqlparse = "^0.5.0"
-
+python = ">=3.12.3,<4.0"
+sqlparse = ">=0.5.0"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.4.8"


### PR DESCRIPTION
Use `>=` in pyproject.toml dependencies to allow using `sql-compare` with an higher version of those dependencies.