### PR TITLE
ci: fix release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,13 +15,10 @@ jobs:
       - uses: actions/setup-python@v5.1.0
         with:
           python-version: ">=3.12"
-      - name: Get version
-        run: |
-          echo "version=$(poetry version --short)" >> "$GITHUB_ENV"
       - run: |
-          git tag $version
-          git push origin $version
           pip install -r requirements-poetry.txt
+          git tag $(poetry version --short)
+          git push origin $(poetry version --short)
           poetry self add poetry-version-plugin
           poetry install --sync
           poetry build


### PR DESCRIPTION
The command to retrieve the version didn't work as Poetry isn't installed at this step.

Fixes MRGFY-3690