### PR TITLE
ci(mergify): don't check Python 3.8 tests

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,7 +5,6 @@ queue_rules:
     allow_inplace_checks: true
     queue_conditions:
       - and: &CheckRuns
-          - check-success=Test with Python 3.8
           - check-success=Test with Python 3.9
           - check-success=Test with Python 3.10
           - check-success=Test with Python 3.11


### PR DESCRIPTION
We'll remove support to bump Poetry to v2.