### PR TITLE
feat(pypi): automatic pypi release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: Upload release to PyPI
 on:
-  workflow_dispatch:
+  release:
+    types:
+      - published
 
 jobs:
   pypi-publish:
@@ -17,8 +19,6 @@ jobs:
           python-version: ">=3.12"
       - run: |
           pip install -r requirements-poetry.txt
-          git tag $(poetry version --short)
-          git push origin $(poetry version --short)
           poetry self add poetry-version-plugin
           poetry sync
           poetry build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sql-compare"
-version = "0.1.3"
+version = "0"
 description = "Compare SQL schemas"
 authors = [{ name = "Charly Laurent", email = "charly.laurent@mergify.com" }]
 maintainers = [{ name = "Mergify", email = "engineering@mergify.com" }]


### PR DESCRIPTION
Currently, we have to trigger a workflow manually to release sql-compare on PyPI.

We should trigger this workflow automatically whenever we create a release on sql-compare, like we do for `pytest-mergify`.

Fixes MRGFY-4860