### PR TITLE
ci: fix release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: ">=3.12"
       - run: |
           pip install -r requirements-poetry.txt
-          poetry self add poetry-version-plugin
+          poetry self add poetry-dynamic-versioning[plugin]
           poetry sync
           poetry build
       - name: Publish package distributions to PyPI


### PR DESCRIPTION
Use `poetry-dynamic-versioning[plugin]` which is not deprecated.