### PR TITLE
fix(ci): Python version for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4.2.2
       - uses: actions/setup-python@v5.4.0
         with:
-          python-version: ">=3.12"
+          python-version: 3.12
       - run: |
           pip install -r requirements-poetry.txt
           poetry self add poetry-dynamic-versioning[plugin]


### PR DESCRIPTION
`rpds-py` cannot be built with Python 3.13.