### PR TITLE
ci: fix poetry-dynamic-versioning configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ poetry-dynamic-versioning = { version = ">=1.0.0,<2.0.0", extras = ["plugin"] }
 
 [tool.poetry-dynamic-versioning]
 enable = true
+vcs = "git"
+pattern = "^(?P<base>\\d+(\\.\\d+)*)"
+format = "{base}"
 
 [build-system]
 requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]


### PR DESCRIPTION
- poetry-dynamic-versioning default regex doesn't find the version in our tags. It expects something like `v0.1.2`, but we use `0.1.2` (without the `v` prefix).
- PyPI doesn't support the local version in the build name. poetry-dynamic-versioning create something like `sql_compare-0.0.0.post1.dev0+fa3962d-py3-none-any.whl`, whild PyPI expects something like `sql_compare-0.1.7-py3-none-any.whl`