### PR TITLE
ci(mergify): don't check Python 3.9 tests

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,6 @@
 extends: .github
 shared:
   check_runs: &CheckRuns
-    - check-success=Test with Python 3.9
     - check-success=Test with Python 3.10
     - check-success=Test with Python 3.11
     - check-success=Test with Python 3.12


### PR DESCRIPTION
Mergify reads its configuration from the default branch, so a pull
request that removes 3.9 from the CI matrix would still be gated on a
`Test with Python 3.9` check run that no longer exists, and could never
merge. Drop the requirement first, on its own, exactly like #142 did
before 3.8 was dropped in #140.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XkWQRxh5pfi2Fbuv3Z9wen