### PR TITLE
ci: test against Python 3.13 and 3.14

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Database",


### PR DESCRIPTION
The classifiers stopped at 3.12 and so did the matrix, while both
internal consumers are already past it: the monorepo `engine` and
`shadow-office` each declare `requires-python = "~=3.14.0"` and pin
`sql-compare==0.2.0`. The library is consumed on 3.14 and tested on
neither 3.13 nor 3.14.

`requires-python = ">=3.10"` is an installability floor, not a support
claim, and it stays unbounded on purpose: a ceiling there breaks `pip
install` on every Python released after it. The classifiers are the
support claim, so they are what this corrects. They only reach users on
the next release; PyPI's current 0.2.0 still advertises `>=3.9` and
stops at 3.12.

Nothing else has to move. `python = "^3.10"` already spans both, so
`poetry.lock`'s `python-versions` and `content-hash` are unchanged
(`poetry check --lock` exits 0; classifiers are not hashed), and every
locked dependency ships cp313 and cp314 wheels, so no leg builds from
source.

Free-threaded 3.14t is left out because nothing here exercises it, not
because it would need different artifacts: `sql_compare` is one
pure-Python module, so `poetry build` emits a single `py3-none-any`
wheel that 3.14t installs unchanged. Adding that leg is its own
decision.

Verified on 3.13.10 and 3.14.6 in clean environments built from
`poetry.lock`: ruff, ruff format, deptry and mypy --strict clean, 64
tests passing on both. The 3.14 leg prints two `SyntaxWarning: 'return'
in a 'finally' block` from pluggy 1.5.0 whenever the bytecode cache is
cold, which on CI is always. They are emitted while pluggy itself is
compiled, before pytest installs `filterwarnings = ["error"]`, so they
are noise on an exit-0 run. Bumping pluggy to 1.6.0 would silence them
and belongs in its own change against the lock.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MKmEnjRuAM4NcTYxRXG3BA