### PR TITLE
ci(mergify): require the Python 3.13 and 3.14 checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,6 +4,8 @@ shared:
     - check-success=Test with Python 3.10
     - check-success=Test with Python 3.11
     - check-success=Test with Python 3.12
+    - check-success=Test with Python 3.13
+    - check-success=Test with Python 3.14
     - check-success=semgrep
   default_review_cond: &DefaultReviewCond
     - "#approved-reviews-by>=1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Database",


### PR DESCRIPTION
The two matrix legs added in the previous commit are advisory on their
own. `.mergify.yml`'s `&CheckRuns` anchor is this repository's only merge
gate: `branches/main/protection` returns no `required_status_checks`, and
none of the eleven active rulesets carries one. So a red 3.13 or 3.14 leg
would land silently.

The ordering mirrors #299 -> #300 but not the reasoning, which is worth
stating rather than assuming symmetric. Removing a check needed its own
pull request first because Mergify reads its configuration from the
default branch: a pull request deleting the job would still have been
gated on a check that no longer reported, and could never merge. Adding
one has no such deadlock. Both pull requests here are evaluated against
main's configuration, which does not name the new checks, so a single
atomic commit would have merged just as well.

What the split actually buys is revertability. If a new leg turns out to
be red on main, reverting this commit alone unblocks the repository while
keeping the coverage the previous commit added; an atomic change would
have to give up both.

Two consequences worth knowing, neither of which ordering can avoid.

Because main's configuration does not require the new checks until this
lands, nothing forces either pull request of this stack to be green on
3.13 or 3.14. Both run the full five-leg matrix on their own head, so the
legs are observable, but they have to be looked at before this one is
merged rather than assumed.

Every pull request already open when this lands keeps the check-run set
from its last CI run, and no `pull_request` event fires when the base
moves. `check-success=Test with Python 3.13` can therefore never go true
on it, and `auto_merge_conditions: true` folds the success conditions
into the queue conditions, so it cannot enter the queue to be rebased out
either. Each one needs a push, a rebase or a close/reopen to pick up the
new legs.

Longer term, this list is a hand-maintained mirror of the job names and
will want the same ceremony at 3.15. The monorepo and mergify-cli both
replaced it with one aggregate job (`all-greens` / `ci-gate`) behind a
single `check-success`, which is worth adopting here on its own. Note
that `check-success~=^Test with Python ` is not a shortcut for it:
check-success is a list attribute and `~=` matches any element, so one
green leg would satisfy it while another fails.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MKmEnjRuAM4NcTYxRXG3BA

Depends-On: #310